### PR TITLE
Pin `jupyterlite-xeus-python` for now

### DIFF
--- a/build-environment.yml
+++ b/build-environment.yml
@@ -6,5 +6,4 @@ dependencies:
   - pip
   - pip:
     - voici>=0.2.0,<0.3.0
-    - jupyterlite-xeus-python
-    - jupyterlite==0.1.0b19
+    - jupyterlite-xeus-python>=0.6.0,<0.7.0

--- a/build-environment.yml
+++ b/build-environment.yml
@@ -7,3 +7,4 @@ dependencies:
   - pip:
     - voici>=0.2.0,<0.3.0
     - jupyterlite-xeus-python
+    - jupyterlite==0.1.0b19

--- a/build-environment.yml
+++ b/build-environment.yml
@@ -7,4 +7,5 @@ dependencies:
   - pip:
     - voici>=0.2.0,<0.3.0
     - jupyterlite-xeus-python>=0.6.0,<0.7.0
+    # TODO: remove when a new voici is available
     - jupyterlite==0.1.0b18

--- a/build-environment.yml
+++ b/build-environment.yml
@@ -7,3 +7,4 @@ dependencies:
   - pip:
     - voici>=0.2.0,<0.3.0
     - jupyterlite-xeus-python>=0.6.0,<0.7.0
+    - jupyterlite==0.1.0b18


### PR DESCRIPTION
This should fix the issue noticed over in https://github.com/voila-dashboards/voici-demo/pull/2.

The latest `jupyterlite-xeus-python` does not install `jupyterlite` (https://github.com/jupyterlite/xeus-python-kernel/pull/114) but the latest `voici` still expects it to import from `jupyterlite.app`.

This should be temporary until there is a new release of Voici and https://github.com/voila-dashboards/voici-demo/pull/2 is merged.