### PR TITLE
Update `voici` and `jupyterlite-xeus-python`

### DIFF
--- a/build-environment.yml
+++ b/build-environment.yml
@@ -5,5 +5,5 @@ dependencies:
   - python
   - pip
   - pip:
-    - voici>=0.3.0,<0.4.0
-    - jupyterlite-xeus-python>=0.7.0,<0.8.0
+    - voici>=0.3.2,<0.4.0
+    - jupyterlite-xeus-python>=0.8.0,<0.9.0


### PR DESCRIPTION
Update to the latest `voici` and `jupyterlite-xeus-python` releases which are based on JupyterLite 0.1.0.