### PR TITLE
Use only one contents CLI option

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Build the JupyterLite site
         shell: bash -l {0}
-        run: voici build --contents content --output-dir dist --XeusAddon.mounts content:/content
+        run: voici build --output-dir dist --XeusAddon.mounts content:/content
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1


### PR DESCRIPTION
Fixes https://github.com/voila-dashboards/voici-demo/issues/19

Since this demo uses the xeus python kernel, and is focused on voici, we can just for the xeus mounting feature.

cc @martinRenou this is addressing the proposal mentioned in https://github.com/voila-dashboards/voici-demo/issues/19.

Additionally, we could link to the Voici / Xeus Python documentation for working with contents.