### PR TITLE
Update `voici` and `jupyterlite-xeus` dependencies

### DIFF
--- a/build-environment.yml
+++ b/build-environment.yml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - jupyterlite-xeus>=2.0.0,<3
-  - voici-core>=0.7,<0.8
+  - voici_core>=0.7,<0.8

--- a/build-environment.yml
+++ b/build-environment.yml
@@ -2,8 +2,5 @@ name: build-env
 channels:
   - conda-forge
 dependencies:
-  - python
-  - pip
-  - pip:
-    - jupyterlite-xeus>=0.1.8,<0.2
-    - voici-core>=0.6,<0.7
+  - jupyterlite-xeus>=2.0.0,<3
+  - voici-core>=0.7,<0.8


### PR DESCRIPTION
Update to the latest versions of `voici` and `jupyterlite-xeus`:

- https://github.com/voila-dashboards/voici/releases/tag/v0.7.0
- https://github.com/jupyterlite/xeus/releases/tag/v2.0.0

Pending https://github.com/conda-forge/voici-feedstock/pull/6